### PR TITLE
Fix broken tests (fastify-cors version and validation error messages)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
   "author": "Cemre Mengu <cemremengu@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "fastify": "^2.0.0-rc.3",
+    "fastify": "^2.0.0",
     "fastify-autoload": "^0.6.0",
     "fastify-cli": "^0.27.0",
-    "fastify-cors": "next",
+    "fastify-cors": "^3.0.3",
     "fastify-helmet": "^3.0.0",
     "fastify-jwt": "^0.8.0",
     "fastify-mongodb": "^1.0.0",

--- a/test/plugins/timestamp.test.js
+++ b/test/plugins/timestamp.test.js
@@ -6,7 +6,7 @@ const { build } = require('../helper')
 test('support works standalone', async (t) => {
   const fastify = build(t)
   await fastify.ready()
-  
+
   const ts = fastify.timestamp()
   t.ok(new Date(ts) > 0)
 })

--- a/test/services/auth.test.js
+++ b/test/services/auth.test.js
@@ -49,7 +49,7 @@ test('test user authentication', async (t) => {
     t.is(res.statusCode, 400)
     t.is(
       payload.message,
-      `body.username should NOT be shorter than 1 characters, body.password should NOT be shorter than 1 characters`
+      `body.username should NOT be shorter than 1 characters`
     )
   })
 
@@ -68,7 +68,7 @@ test('test user authentication', async (t) => {
     t.is(res.statusCode, 400)
     t.is(
       payload.message,
-      `body should have required property 'username', body should have required property 'password'`
+      `body should have required property 'username'`
     )
   })
 })


### PR DESCRIPTION
Tests wouldn't pass on a fresh install because `fastify-cors@latest` stopped `fastify.ready()` from resolving (so timeout).
Then it appears the error messages from the schema validation have changed since this was written: only getting a single error message now, rather than the concatenated messages before.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
