### PR TITLE
docs: replace `fastify.io` links with `fastify.dev`

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -12,5 +12,5 @@ that will then be used in the rest of your application.
 Check out:
 
 * [The hitchhiker's guide to plugins](https://github.com/fastify/fastify/blob/master/docs/Plugins-Guide.md)
-* [Fastify decorators](https://www.fastify.dev/docs/latest/Decorators/).
-* [Fastify lifecycle](https://www.fastify.dev/docs/latest/Lifecycle/).
+* [Fastify decorators](https://fastify.dev/docs/latest/Decorators/).
+* [Fastify lifecycle](https://fastify.dev/docs/latest/Lifecycle/).

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -12,5 +12,5 @@ that will then be used in the rest of your application.
 Check out:
 
 * [The hitchhiker's guide to plugins](https://github.com/fastify/fastify/blob/master/docs/Plugins-Guide.md)
-* [Fastify decorators](https://www.fastify.io/docs/latest/Decorators/).
-* [Fastify lifecycle](https://www.fastify.io/docs/latest/Lifecycle/).
+* [Fastify decorators](https://www.fastify.dev/docs/latest/Decorators/).
+* [Fastify lifecycle](https://www.fastify.dev/docs/latest/Lifecycle/).

--- a/services/README.md
+++ b/services/README.md
@@ -7,7 +7,7 @@ to independently deploy some of those.
 In this folder you should define all the services that define the routes
 of your web application.
 Each service is a [Fastify
-plugin](https://www.fastify.dev/docs/latest/Plugins/), it is
+plugin](https://fastify.dev/docs/latest/Plugins/), it is
 encapsulated (it can have its own independent plugins) and it is
 typically stored in a file; be careful to group your routes logically,
 e.g. all `/users` routes in a `users.js` file. We have added
@@ -21,4 +21,4 @@ and eventually extract them.
 
 If you need to share functionality between services, place that
 functionality into the `plugins` folder, and share it via
-[decorators](https://www.fastify.dev/docs/latest/Decorators/).
+[decorators](https://fastify.dev/docs/latest/Decorators/).

--- a/services/README.md
+++ b/services/README.md
@@ -7,7 +7,7 @@ to independently deploy some of those.
 In this folder you should define all the services that define the routes
 of your web application.
 Each service is a [Fastify
-plugin](https://www.fastify.io/docs/latest/Plugins/), it is
+plugin](https://www.fastify.dev/docs/latest/Plugins/), it is
 encapsulated (it can have its own independent plugins) and it is
 typically stored in a file; be careful to group your routes logically,
 e.g. all `/users` routes in a `users.js` file. We have added
@@ -21,4 +21,4 @@ and eventually extract them.
 
 If you need to share functionality between services, place that
 functionality into the `plugins` folder, and share it via
-[decorators](https://www.fastify.io/docs/latest/Decorators/).
+[decorators](https://www.fastify.dev/docs/latest/Decorators/).


### PR DESCRIPTION
See https://github.com/fastify/ajv-compiler/pull/115

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
